### PR TITLE
Bug with Safari, zooms-in while using input fields 

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { AppProps } from 'next/app';
 import { Cabin } from '@next/font/google';
-import { MantineProvider } from '@mantine/core';
+import { MantineProvider, PasswordInput } from '@mantine/core';
 
 const cabin = Cabin({
   subsets: ['latin']
@@ -18,7 +18,19 @@ export default function MyApp({ Component, pageProps }: AppProps) {
       withNormalizeCSS
       theme={{
         /** Put your mantine theme override here */
-        colorScheme: 'light'
+        colorScheme: 'light',
+        components: {
+          TextInput: {
+            styles: {
+              input: { fontSize: "16px" },
+            },
+          },
+          PasswordInput: {
+            styles: {
+              innerInput: { fontSize: "16px" },
+            },
+          },
+        },
       }}
     >
       <QueryClientProvider client={queryClient}>

--- a/src/pages/participate.tsx
+++ b/src/pages/participate.tsx
@@ -90,7 +90,6 @@ const Participate = () => {
                   required: 'This field is required',
                   pattern: { value: emailRegex(), message: 'Please provide a valid email address' }
                 })}
-                sx={{ width: '260px' }}
               />
               <ErrorMessage>{errors.email?.message}</ErrorMessage>
             </div>
@@ -101,7 +100,6 @@ const Participate = () => {
                 aria-label="full name input field"
                 placeholder="Full name"
                 {...register('fullName', { required: 'This field is required' })}
-                sx={{ width: '260px' }}
               />
               <ErrorMessage>{errors.fullName?.message}</ErrorMessage>
             </div>


### PR DESCRIPTION
**Bug**  _(Only for safari)_

When entering in an input field 
- participate information (users)
- password (admin) 

It zooms-in and keeps the zoom even after redirecting to the next page

**Solution**

Set global style, in MantineProvider,  to use font size 16px 

> If font size is less than 16px, safari zooms-in by itself :)